### PR TITLE
Fix vertical scroll bars

### DIFF
--- a/disk-files/CHAP02/SYSMETS3.C
+++ b/disk-files/CHAP02/SYSMETS3.C
@@ -82,6 +82,9 @@ long FAR PASCAL _export WndProc (HWND hwnd, UINT message, UINT wParam,
                cxClient = LOWORD (lParam) ;
                cyClient = HIWORD (lParam) ;
 
+               nVscrollMax = max (0, NUMLINES + 2 - cyClient / cyChar) ;
+               nVscrollPos = min (nVscrollPos, nVscrollMax) ;
+
                SetScrollRange (hwnd, SB_VERT, 0, nVscrollMax, FALSE) ;
                SetScrollPos   (hwnd, SB_VERT, nVscrollPos, TRUE) ;
 


### PR DESCRIPTION
The original Programming Windows 3.1 book and companion disk were missing two lines in the SYSMETS3.C program, resulting in the vertical scroll bar not appearing correctly. This is reflected in the correction notice available at https://jeffpar.github.io/kbarchive/kb/125/Q125415/.